### PR TITLE
Load drives with powershell

### DIFF
--- a/src/FanControl.HardDiskSentinel/Drive.cs
+++ b/src/FanControl.HardDiskSentinel/Drive.cs
@@ -1,6 +1,6 @@
 ﻿namespace FanControl.HardDiskSentinel
 {
-    public class Drive
+    public readonly struct Drive
     {
         private Drive(string model, string serial, string firmware, string temperature)
         {

--- a/src/FanControl.HardDiskSentinel/Drive.cs
+++ b/src/FanControl.HardDiskSentinel/Drive.cs
@@ -1,112 +1,26 @@
-﻿using System;
-
-namespace FanControl.HardDiskSentinel
+﻿namespace FanControl.HardDiskSentinel
 {
-    public class DriveBasic
+    public class Drive
     {
-        public DriveBasic()
+        private Drive(string model, string serial, string firmware, string temperature)
         {
-            Initialized = false;
-            Model = "";
-            Serial = "";
-            FirmwareRev = "";
-            InterfaceType = "";
-            PowerOnTime = "";
-            Temperature = "";
-        }
-
-        public bool Initialized { get; set; }
-
-        public string Model { get; set; }
-        public string Serial { get; set; }
-        public string FirmwareRev { get; set; }
-        public string InterfaceType { get; set; }
-        public string PowerOnTime { get; set; }
-        public string Temperature { get; set; }
-
-        public void InitValues(string model, string serial, string firmware, string interfaceType, string powerOnTime, string temperature)
-        {
-            Initialized = true;
             Model = model;
             Serial = serial;
-            FirmwareRev = firmware;
-            InterfaceType = interfaceType;
-            PowerOnTime = powerOnTime;
+            Firmware = firmware;
             Temperature = temperature;
         }
-    }
 
-    public class Drive : DriveBasic
-    {
-        public Drive()
+        public string Model { get; }
+        public string Serial { get; }
+        public string Firmware { get; }
+        public string Temperature { get; }
+
+        public static class Factory
         {
-            Initialized = false;
-            Model = "";
-            Serial = "";
-            FirmwareRev = "";
-            InterfaceType = "";
-            PowerOnTime = "";
-            PowerOnHours = "";
-            StartStopCount = "";
-            BadSectorCount = "";
-            WeakSectorCount = "";
-            SpinRetryCount = "";
-            CommunicationIssueCount = "";
-            StatusCode = "";
-            TrimStatus = "";
-            Report = "";
-            Health = "";
-            Performance = "";
-            LifetimeWrites = "";
-            SmartDATA = "";
+            public static Drive Build(string model, string serial, string firmware, string temperature)
+            {
+                return new Drive(model, serial, firmware, temperature);
+            }
         }
-        
-        public void PopulateData(string powerOnHrs, string startStop, string badSector, string weakSector, string spinRetry, string commIssue, string statusCode, string trim)
-        {
-            PowerOnHours = powerOnHrs;
-            StartStopCount = startStop;
-            BadSectorCount = badSector;
-            WeakSectorCount = weakSector;
-            SpinRetryCount = spinRetry;
-            CommunicationIssueCount = commIssue;
-            StatusCode = statusCode;
-            TrimStatus = trim;
-        }
-
-        public void PopulateReport(string report, string health, string perf, string writes, string smart)
-        {
-            Report = report;
-            Health = health;
-            Performance = perf;
-            LifetimeWrites = writes;
-            SmartDATA = smart;
-        }
-
-        public void PrintReport()
-        {
-            Console.WriteLine("Model: " + Model);
-            Console.WriteLine("Serial: " + Serial);
-            Console.WriteLine("Health: " + Health);
-            Console.WriteLine("Power On Time: " + PowerOnTime);
-            Console.WriteLine("Power On Hours: " + PowerOnHours);
-            Console.WriteLine("Total Writes: " + LifetimeWrites);
-            Console.WriteLine("Performance: " + Performance);
-        }
-
-        public string PowerOnHours { get; set; }
-        public string StartStopCount { get; set; }
-        public string BadSectorCount { get; set; }
-        public string WeakSectorCount { get; set; }
-        public string SpinRetryCount { get; set; }
-        public string CommunicationIssueCount { get; set; }
-        public string StatusCode { get; set; }
-        public string TrimStatus { get; set; }
-
-        public string Report { get; set; }
-        public string Health { get; set; }
-        public string Performance { get; set; }
-        public string LifetimeWrites { get; set; }
-
-        public string SmartDATA { get; set; }
     }
 }

--- a/src/FanControl.HardDiskSentinel/DriveInfoReader.cs
+++ b/src/FanControl.HardDiskSentinel/DriveInfoReader.cs
@@ -1,59 +1,25 @@
 ﻿using System.Management;
+using System.Management.Automation;
 
 namespace FanControl.HardDiskSentinel
 {
     public static class DriveInfoReader
     {
-        public static Drive Read(ManagementObject managementObject)
+        public static Drive ReadBasic(ManagementObject managementObject)
         {
-            var drive = new Drive();
-
-            // Functions separated to make it easier to read
-            drive.InitValues(
+            return Drive.Factory.Build(
                 managementObject.GetPropertyValue("ModelID").ToString().Trim(),
                 managementObject.GetPropertyValue("SerialNumber").ToString().Trim(),
                 managementObject.GetPropertyValue("FirmwareRevision").ToString().Trim(),
-                managementObject.GetPropertyValue("Interface").ToString().Trim(),
-                managementObject.GetPropertyValue("PowerOnTime").ToString().Trim(),
-                managementObject.GetPropertyValue("TemperatureC").ToString().Trim()
-            );
-
-            drive.PopulateData(
-                managementObject.GetPropertyValue("PowerOnHours").ToString().Trim(),
-                managementObject.GetPropertyValue("StartStopCount").ToString().Trim(),
-                managementObject.GetPropertyValue("BadSectorCount").ToString().Trim(),
-                managementObject.GetPropertyValue("WeakSectorCount").ToString().Trim(),
-                managementObject.GetPropertyValue("SpinRetryCount").ToString().Trim(),
-                managementObject.GetPropertyValue("CommunicationIssueCount").ToString().Trim(),
-                managementObject.GetPropertyValue("StatusCode").ToString().Trim(),
-                managementObject.GetPropertyValue("TRIMStatus").ToString().Trim()
-            );
-
-            drive.PopulateReport(
-                managementObject.GetPropertyValue("Report").ToString().Trim(),
-                managementObject.GetPropertyValue("Health").ToString().Trim(),
-                managementObject.GetPropertyValue("Performance").ToString().Trim(),
-                managementObject.GetPropertyValue("LifetimeWriteMB").ToString().Trim(),
-                managementObject.GetPropertyValue("SMART").ToString().Trim()
-            );
-
-            return drive;
+                managementObject.GetPropertyValue("TemperatureC").ToString().Trim());
         }
 
-        public static DriveBasic ReadBasic(ManagementObject managementObject)
+        public static Drive Read(PSObject managementObject)
         {
-            var drive = new DriveBasic();
-
-            drive.InitValues(
-                managementObject.GetPropertyValue("ModelID").ToString().Trim(),
-                managementObject.GetPropertyValue("SerialNumber").ToString().Trim(),
-                managementObject.GetPropertyValue("FirmwareRevision").ToString().Trim(),
-                managementObject.GetPropertyValue("Interface").ToString().Trim(),
-                managementObject.GetPropertyValue("PowerOnTime").ToString().Trim(),
-                managementObject.GetPropertyValue("TemperatureC").ToString().Trim()
-            );
-
-            return drive;
+            return Drive.Factory.Build(managementObject.Properties["Model"].Value.ToString(),
+                managementObject.Properties["SerialNumber"].Value.ToString(),
+                managementObject.Properties["FirmwareVersion"].Value.ToString(),
+                36.ToString());
         }
     }
 }

--- a/src/FanControl.HardDiskSentinel/DriveInfoReader.cs
+++ b/src/FanControl.HardDiskSentinel/DriveInfoReader.cs
@@ -5,7 +5,7 @@ namespace FanControl.HardDiskSentinel
 {
     public static class DriveInfoReader
     {
-        public static Drive ReadBasic(ManagementObject managementObject)
+        public static Drive ReadFromWmi(ManagementObject managementObject)
         {
             return Drive.Factory.Build(
                 managementObject.GetPropertyValue("ModelID").ToString().Trim(),
@@ -14,7 +14,7 @@ namespace FanControl.HardDiskSentinel
                 managementObject.GetPropertyValue("TemperatureC").ToString().Trim());
         }
 
-        public static Drive Read(PSObject managementObject)
+        public static Drive ReadFromPowerShell(PSObject managementObject)
         {
             return Drive.Factory.Build(managementObject.Properties["Model"].Value.ToString(),
                 managementObject.Properties["SerialNumber"].Value.ToString(),

--- a/src/FanControl.HardDiskSentinel/FanControl.HardDiskSentinel.csproj
+++ b/src/FanControl.HardDiskSentinel/FanControl.HardDiskSentinel.csproj
@@ -6,6 +6,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+	  <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
 	  <PackageReference Include="System.Management" Version="5.0.0" />
 	</ItemGroup>
 

--- a/src/FanControl.HardDiskSentinel/HardDiskSentinelPlugin.cs
+++ b/src/FanControl.HardDiskSentinel/HardDiskSentinelPlugin.cs
@@ -23,7 +23,7 @@ namespace FanControl.HardDiskSentinel
             ps.AddScript("Get-PhysicalDisk | where {($_.CannotPoolReason -match 'In a Pool')}");
 
             var disks = ps.Invoke()
-                .Select(DriveInfoReader.Read)
+                .Select(DriveInfoReader.ReadFromPowerShell)
                 .ToArray();
 
             var sensors = disks.Select(d => new PluginSensor(d));

--- a/src/FanControl.HardDiskSentinel/HardDiskSentinelPlugin.cs
+++ b/src/FanControl.HardDiskSentinel/HardDiskSentinelPlugin.cs
@@ -1,4 +1,5 @@
-﻿using FanControl.Plugins;
+﻿using System;
+using FanControl.Plugins;
 using System.Linq;
 using System.Management.Automation;
 
@@ -26,9 +27,14 @@ namespace FanControl.HardDiskSentinel
                 .Select(DriveInfoReader.ReadFromPowerShell)
                 .ToArray();
 
-            var sensors = disks.Select(d => new PluginSensor(d));
+            var sensors = disks.Select(BuildPluginSensor);
 
             container.TempSensors.AddRange(sensors);
+        }
+
+        private static PluginSensor BuildPluginSensor(Drive drive)
+        {
+            return new PluginSensor(drive);
         }
     }
 }

--- a/src/FanControl.HardDiskSentinel/HardDiskSentinelPlugin.cs
+++ b/src/FanControl.HardDiskSentinel/HardDiskSentinelPlugin.cs
@@ -1,6 +1,6 @@
 ﻿using FanControl.Plugins;
 using System.Linq;
-using System.Management;
+using System.Management.Automation;
 
 namespace FanControl.HardDiskSentinel
 {
@@ -18,17 +18,15 @@ namespace FanControl.HardDiskSentinel
 
         public void Load(IPluginSensorsContainer container)
         {
-            // Get Drives from WMI
-            var scope = new ManagementScope(@"root\wmi");
-            var query = new ObjectQuery("SELECT * FROM HDSentinel");
+            var ps = PowerShell.Create();
 
-            using var searcher = new ManagementObjectSearcher(scope, query);
+            ps.AddScript("Get-PhysicalDisk | where {($_.CannotPoolReason -match 'In a Pool')}");
 
-            var drives = searcher.Get()
-                .Cast<ManagementObject>()
-                .Select(DriveInfoReader.Read);
+            var disks = ps.Invoke()
+                .Select(DriveInfoReader.Read)
+                .ToArray();
 
-            var sensors = drives.Select(drive => new PluginSensor(drive));
+            var sensors = disks.Select(d => new PluginSensor(d));
 
             container.TempSensors.AddRange(sensors);
         }

--- a/src/FanControl.HardDiskSentinel/PluginSensor.cs
+++ b/src/FanControl.HardDiskSentinel/PluginSensor.cs
@@ -30,7 +30,7 @@ namespace FanControl.HardDiskSentinel
                 var items = searcher.Get();
 
                 temperature = items.Cast<ManagementObject>()
-                    .Select(DriveInfoReader.ReadBasic)
+                    .Select(DriveInfoReader.ReadFromWmi)
                     .Where(drive => drive.Model == _drive.Model && drive.Serial == _drive.Serial)
                     .Select(drive => drive.Temperature)
                     .Select(float.Parse)

--- a/src/FanControl.HardDiskSentinel/PluginSensor.cs
+++ b/src/FanControl.HardDiskSentinel/PluginSensor.cs
@@ -1,6 +1,7 @@
-﻿using System.Linq;
+﻿using FanControl.Plugins;
+using System.Diagnostics;
+using System.Linq;
 using System.Management;
-using FanControl.Plugins;
 
 namespace FanControl.HardDiskSentinel
 {
@@ -21,16 +22,26 @@ namespace FanControl.HardDiskSentinel
 
         public void Update()
         {
-            
             using var searcher = new ManagementObjectSearcher(_scope, _query);
 
-            var items = searcher.Get();
+            float temperature = 36;
+            try
+            {
+                var items = searcher.Get();
 
-            var temperature = items.Cast<ManagementObject>()
-                .Select(DriveInfoReader.ReadBasic)
-                .Where(drive => drive.Model == _drive.Model && drive.Serial == _drive.Serial)
-                .Select(drive => drive.Temperature)
-                .Select(float.Parse).FirstOrDefault();
+                temperature = items.Cast<ManagementObject>()
+                    .Select(DriveInfoReader.ReadBasic)
+                    .Where(drive => drive.Model == _drive.Model && drive.Serial == _drive.Serial)
+                    .Select(drive => drive.Temperature)
+                    .Select(float.Parse)
+                    .FirstOrDefault();
+            }
+            catch (ManagementException exception)
+            {
+#if DEBUG
+                Debug.Print(exception.ToString());
+#endif
+            }
 
             Value = temperature;
         }

--- a/src/FanControl.HardDiskSentinel/PluginSensor.cs
+++ b/src/FanControl.HardDiskSentinel/PluginSensor.cs
@@ -7,6 +7,8 @@ namespace FanControl.HardDiskSentinel
     public class PluginSensor : IPluginSensor
     {
         private readonly Drive _drive;
+        private readonly ManagementScope _scope = new ManagementScope(@"root\wmi");
+        private readonly ObjectQuery _query = new ObjectQuery("SELECT * FROM HDSentinel");
 
         public PluginSensor(Drive drive)
         {
@@ -19,17 +21,14 @@ namespace FanControl.HardDiskSentinel
 
         public void Update()
         {
-            var scope = new ManagementScope(@"root\wmi");
-            var query = new ObjectQuery("SELECT * FROM HDSentinel");
-
-            using var searcher = new ManagementObjectSearcher(scope, query);
+            
+            using var searcher = new ManagementObjectSearcher(_scope, _query);
 
             var items = searcher.Get();
 
             var temperature = items.Cast<ManagementObject>()
                 .Select(DriveInfoReader.ReadBasic)
-                .Where(drive => drive.Model == _drive.Model &&
-                                drive.Serial == _drive.Serial)
+                .Where(drive => drive.Model == _drive.Model && drive.Serial == _drive.Serial)
                 .Select(drive => drive.Temperature)
                 .Select(float.Parse).FirstOrDefault();
 


### PR DESCRIPTION
Load drives initially using PowerShell instead of Hard Disk Sentinel to avoid errors in case it is not already launched